### PR TITLE
Add tests to raise coverage above 85%

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -39,7 +39,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Retrieve a user
     if let Some(user) = cache.get(&"user:1".to_string()).await? {
-        println!("Found user: {:?}", user);
+        println!("Found user: {user:?}");
     }
 
     // Check if a key exists
@@ -56,7 +56,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Remove a user
     if let Some(removed) = cache.remove(&"user:1".to_string()).await? {
-        println!("Removed user: {:?}", removed);
+        println!("Removed user: {removed:?}");
     }
 
     // Clear the cache

--- a/examples/simple_test.rs
+++ b/examples/simple_test.rs
@@ -57,7 +57,7 @@ async fn main() -> std::result::Result<(), Box<dyn Error>> {
 
     // Cache statistics
     let len = cache.len().await?;
-    println!("📊 Cache has {} entries", len);
+    println!("📊 Cache has {len} entries");
 
     // Remove operation
     if let Some(removed) = cache.remove(&"test_key".to_string()).await? {

--- a/src/backends/filesystem.rs
+++ b/src/backends/filesystem.rs
@@ -163,13 +163,13 @@ where
                         }
                         Err(e) => {
                             // Log error but continue loading other files
-                            eprintln!("Failed to deserialize cache file {:?}: {}", path, e);
+                            eprintln!("Failed to deserialize cache file {path:?}: {e}");
                         }
                     }
                 }
                 Err(e) => {
                     // Log error but continue loading other files
-                    eprintln!("Failed to read cache file {:?}: {}", path, e);
+                    eprintln!("Failed to read cache file {path:?}: {e}");
                 }
             }
         }
@@ -316,8 +316,8 @@ mod tests {
         // Save some data
         let mut entries = HashMap::new();
         for i in 0..5 {
-            let entry = CacheEntry::new(format!("key{}", i), format!("value{}", i));
-            entries.insert(format!("key{}", i), vec![entry]);
+            let entry = CacheEntry::new(format!("key{i}"), format!("value{i}"));
+            entries.insert(format!("key{i}"), vec![entry]);
         }
 
         backend.save(&entries).await.unwrap();
@@ -353,18 +353,14 @@ mod tests {
             // Ensure the path is within the base directory
             assert!(
                 path.starts_with(&backend.base_path),
-                "Malicious key '{}' resulted in path outside base directory: {:?}",
-                malicious_key,
-                path
+                "Malicious key '{malicious_key}' resulted in path outside base directory: {path:?}"
             );
 
             // Ensure the filename doesn't contain path separators
             let filename = path.file_name().unwrap().to_str().unwrap();
             assert!(
                 !filename.contains('/') && !filename.contains('\\'),
-                "Filename '{}' contains path separators for key '{}'",
-                filename,
-                malicious_key
+                "Filename '{filename}' contains path separators for key '{malicious_key}'"
             );
         }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -467,6 +467,7 @@ mod tests {
         use tokio::sync::RwLock;
 
         #[derive(Clone, Default)]
+        #[allow(clippy::type_complexity)]
         struct MockBackend {
             entries: Arc<RwLock<HashMap<String, Vec<CacheEntry<String, String, ()>>>>>,
             save_calls: Arc<RwLock<usize>>,
@@ -481,7 +482,10 @@ mod tests {
 
             async fn save(
                 &self,
-                entries: &HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>,
+                entries: &HashMap<
+                    Self::Key,
+                    Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>,
+                >,
             ) -> Result<()> {
                 *self.save_calls.write().await += 1;
                 *self.entries.write().await = entries.clone();
@@ -490,7 +494,8 @@ mod tests {
 
             async fn load(
                 &self,
-            ) -> Result<HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>> {
+            ) -> Result<HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>>
+            {
                 *self.load_calls.write().await += 1;
                 Ok(self.entries.read().await.clone())
             }
@@ -528,10 +533,7 @@ mod tests {
         assert_eq!(*backend.load_calls.read().await, 1);
 
         // Put new entry triggers save due to sync_interval=1
-        cache
-            .put("k".to_string(), "v".to_string())
-            .await
-            .unwrap();
+        cache.put("k".to_string(), "v".to_string()).await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert!(*backend.save_calls.read().await >= 1);
         assert!(backend.entries.read().await.contains_key("k"));

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -375,6 +375,7 @@ pub struct CacheStats {
 mod tests {
     use super::*;
     use crate::backends::memory::MemoryBackend;
+    use crate::SearchQuery;
 
     #[tokio::test]
     async fn test_cache_basic_operations() {
@@ -423,5 +424,116 @@ mod tests {
         cache.clear().await.unwrap();
         assert_eq!(cache.len().await.unwrap(), 0);
         assert!(!cache.contains(&"key1".to_string()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_cache_entries_search_stats() {
+        let config = CacheConfig::default();
+        let backend = MemoryBackend::new();
+        let cache: Cache<String, String> = Cache::new(config, backend).await.unwrap();
+
+        cache
+            .add_entry(CacheEntry::new("key".to_string(), "v1".to_string()))
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        cache
+            .add_entry(CacheEntry::new("key".to_string(), "v2".to_string()))
+            .await
+            .unwrap();
+
+        let entries = cache.get_entries(&"key".to_string()).await.unwrap();
+        assert_eq!(entries.len(), 2);
+        let latest = cache.get_latest(&"key".to_string()).await.unwrap();
+        assert_eq!(latest.value, "v2");
+
+        let results = cache.search(&SearchQuery::new().with_pattern("key")).await;
+        assert_eq!(results.len(), 2);
+
+        // Add expired entry for stats
+        let expired = CacheEntry::new("expired".to_string(), "v".to_string())
+            .with_ttl(chrono::Duration::seconds(-1));
+        cache.add_entry(expired).await.unwrap();
+
+        let stats = cache.get_stats().await;
+        assert_eq!(stats.total_entries, 3);
+        assert!(stats.expired_count >= 1);
+        assert!(stats.total_access_count >= 2); // accesses from get_entries/get_latest
+    }
+
+    #[tokio::test]
+    async fn test_cache_persistence() {
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        #[derive(Clone, Default)]
+        struct MockBackend {
+            entries: Arc<RwLock<HashMap<String, Vec<CacheEntry<String, String, ()>>>>>,
+            save_calls: Arc<RwLock<usize>>,
+            load_calls: Arc<RwLock<usize>>,
+        }
+
+        #[async_trait::async_trait]
+        impl StorageBackend for MockBackend {
+            type Key = String;
+            type Value = String;
+            type Metadata = ();
+
+            async fn save(
+                &self,
+                entries: &HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>,
+            ) -> Result<()> {
+                *self.save_calls.write().await += 1;
+                *self.entries.write().await = entries.clone();
+                Ok(())
+            }
+
+            async fn load(
+                &self,
+            ) -> Result<HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>> {
+                *self.load_calls.write().await += 1;
+                Ok(self.entries.read().await.clone())
+            }
+
+            async fn remove(&self, key: &Self::Key) -> Result<()> {
+                self.entries.write().await.remove(key);
+                Ok(())
+            }
+
+            async fn clear(&self) -> Result<()> {
+                self.entries.write().await.clear();
+                Ok(())
+            }
+        }
+
+        let backend = MockBackend::default();
+        // Preload backend
+        backend
+            .save(&HashMap::from([(
+                "loaded".to_string(),
+                vec![CacheEntry::new("loaded".to_string(), "v".to_string())],
+            )]))
+            .await
+            .unwrap();
+
+        let mut config = CacheConfig::default();
+        config.persistence.enabled = true;
+        config.persistence.load_on_startup = true;
+        config.persistence.sync_interval = 1;
+
+        let cache: Cache<String, String, (), MockBackend> =
+            Cache::new(config, backend.clone()).await.unwrap();
+        // Loaded entry should be present
+        assert!(cache.contains(&"loaded".to_string()).await.unwrap());
+        assert_eq!(*backend.load_calls.read().await, 1);
+
+        // Put new entry triggers save due to sync_interval=1
+        cache
+            .put("k".to_string(), "v".to_string())
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(*backend.save_calls.read().await >= 1);
+        assert!(backend.entries.read().await.contains_key("k"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,6 +225,21 @@ mod tests {
         assert!(persistence.load_on_startup);
     }
 
+    #[test]
+    fn test_persistence_config_disabled() {
+        let persistence = PersistenceConfig::disabled();
+        assert!(!persistence.enabled);
+        assert_eq!(persistence.path, None);
+    }
+
+    #[test]
+    fn test_with_persistence_builder() {
+        let p = PersistenceConfig::with_path("/tmp/data");
+        let config = CacheConfig::new().with_persistence(p.clone());
+        assert!(config.persistence.enabled);
+        assert_eq!(config.persistence.path, p.path);
+    }
+
     #[cfg(feature = "compression")]
     #[test]
     fn test_compression_config() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,22 +79,24 @@ mod tests {
         matches!(io_err, CacheError::Io(_));
 
         let ser_err = CacheError::Serialization("ser".into());
-        assert_eq!(format!("{}", ser_err), "Serialization error: ser");
+        assert_eq!(format!("{ser_err}"), "Serialization error: ser");
 
         let des_err = CacheError::Deserialization("de".into());
-        assert_eq!(format!("{}", des_err), "Deserialization error: de");
+        assert_eq!(format!("{des_err}"), "Deserialization error: de");
 
-        let cap_err = CacheError::CapacityExceeded { message: "full".into() };
+        let cap_err = CacheError::CapacityExceeded {
+            message: "full".into(),
+        };
         assert!(matches!(cap_err, CacheError::CapacityExceeded { .. }));
 
         let backend_err = CacheError::StorageBackend("be".into());
         assert!(matches!(backend_err, CacheError::StorageBackend(_)));
 
         let not_found = CacheError::NotFound;
-        assert_eq!(format!("{}", not_found), "Entry not found for key");
+        assert_eq!(format!("{not_found}"), "Entry not found for key");
 
         let custom = CacheError::Custom("c".into());
-        assert_eq!(format!("{}", custom), "Custom error: c");
+        assert_eq!(format!("{custom}"), "Custom error: c");
     }
 
     #[cfg(feature = "json-serialization")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,3 +68,40 @@ impl From<bincode::Error> for CacheError {
         CacheError::Serialization(err.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_error_variants() {
+        let io_err: CacheError = io::Error::new(io::ErrorKind::Other, "oops").into();
+        matches!(io_err, CacheError::Io(_));
+
+        let ser_err = CacheError::Serialization("ser".into());
+        assert_eq!(format!("{}", ser_err), "Serialization error: ser");
+
+        let des_err = CacheError::Deserialization("de".into());
+        assert_eq!(format!("{}", des_err), "Deserialization error: de");
+
+        let cap_err = CacheError::CapacityExceeded { message: "full".into() };
+        assert!(matches!(cap_err, CacheError::CapacityExceeded { .. }));
+
+        let backend_err = CacheError::StorageBackend("be".into());
+        assert!(matches!(backend_err, CacheError::StorageBackend(_)));
+
+        let not_found = CacheError::NotFound;
+        assert_eq!(format!("{}", not_found), "Entry not found for key");
+
+        let custom = CacheError::Custom("c".into());
+        assert_eq!(format!("{}", custom), "Custom error: c");
+    }
+
+    #[cfg(feature = "json-serialization")]
+    #[test]
+    fn test_cache_error_from_json() {
+        // malformed JSON triggers serialization error
+        let result: Result<serde_json::Value> = serde_json::from_str("{]").map_err(Into::into);
+        assert!(matches!(result, Err(CacheError::Serialization(_))));
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -239,7 +239,10 @@ mod tests {
     fn test_search_query_timestamp_category() {
         let now = Utc::now();
         let query = SearchQuery::new()
-            .with_timestamp_range(Some(now - chrono::Duration::seconds(1)), Some(now + chrono::Duration::seconds(1)))
+            .with_timestamp_range(
+                Some(now - chrono::Duration::seconds(1)),
+                Some(now + chrono::Duration::seconds(1)),
+            )
             .with_category("api");
         assert!(query.min_timestamp.is_some());
         assert_eq!(query.category, Some("api".to_string()));

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -121,9 +121,9 @@ pub struct StorageStats {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(feature = "json-serialization", feature = "bincode-serialization"))]
     use super::*;
-
+    use async_trait::async_trait;
+    #[cfg(any(feature = "json-serialization", feature = "bincode-serialization"))]
     #[test]
     fn test_serialization_format_extension() {
         #[cfg(feature = "json-serialization")]
@@ -161,6 +161,7 @@ mod tests {
         use tokio::sync::RwLock;
 
         #[derive(Default)]
+        #[allow(clippy::type_complexity)]
         struct DummyBackend {
             entries: Arc<RwLock<HashMap<String, Vec<CacheEntry<String, String, ()>>>>>,
         }
@@ -173,7 +174,10 @@ mod tests {
 
             async fn save(
                 &self,
-                entries: &HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>,
+                entries: &HashMap<
+                    Self::Key,
+                    Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>,
+                >,
             ) -> Result<()> {
                 *self.entries.write().await = entries.clone();
                 Ok(())
@@ -181,7 +185,8 @@ mod tests {
 
             async fn load(
                 &self,
-            ) -> Result<HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>> {
+            ) -> Result<HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>>
+            {
                 Ok(self.entries.read().await.clone())
             }
 


### PR DESCRIPTION
## Summary
- expand cache tests to cover entry retrieval, searching, stats, and persistence
- exercise error handling, config builders, storage backends, and search branches

## Testing
- `cargo test`
- `cargo tarpaulin --out Xml`

------
https://chatgpt.com/codex/tasks/task_e_68a3fde2a44c8327af125df489a3121f