### PR TITLE
Refactor backend tests to reduce duplication

### DIFF
--- a/src/backends/filesystem.rs
+++ b/src/backends/filesystem.rs
@@ -241,41 +241,6 @@ mod tests {
     use tempfile::TempDir;
 
     #[tokio::test]
-    async fn test_filesystem_backend_operations() {
-        let temp_dir = TempDir::new().unwrap();
-        let backend: FilesystemBackend<String, String> =
-            FilesystemBackend::new(temp_dir.path()).await.unwrap();
-
-        // Test empty state
-        let loaded = backend.load().await.unwrap();
-        assert!(loaded.is_empty());
-
-        // Test save and load
-        let mut entries = HashMap::new();
-        let entry = CacheEntry::new("key1".to_string(), "value1".to_string());
-        entries.insert("key1".to_string(), vec![entry]);
-
-        backend.save(&entries).await.unwrap();
-        let loaded = backend.load().await.unwrap();
-        assert_eq!(loaded.len(), 1);
-        assert!(loaded.contains_key("key1"));
-
-        // Test contains
-        assert!(backend.contains(&"key1".to_string()).await.unwrap());
-        assert!(!backend.contains(&"key2".to_string()).await.unwrap());
-
-        // Test remove
-        backend.remove(&"key1".to_string()).await.unwrap();
-        assert!(!backend.contains(&"key1".to_string()).await.unwrap());
-
-        // Test clear
-        backend.save(&entries).await.unwrap();
-        backend.clear().await.unwrap();
-        let loaded = backend.load().await.unwrap();
-        assert!(loaded.is_empty());
-    }
-
-    #[tokio::test]
     async fn test_filesystem_backend_persistence() {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().to_path_buf();

--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -113,39 +113,6 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_memory_backend_operations() {
-        let backend: MemoryBackend<String, String> = MemoryBackend::new();
-
-        // Test empty state
-        let loaded = backend.load().await.unwrap();
-        assert!(loaded.is_empty());
-
-        // Test save and load
-        let mut entries = HashMap::new();
-        let entry = CacheEntry::new("key1".to_string(), "value1".to_string());
-        entries.insert("key1".to_string(), vec![entry]);
-
-        backend.save(&entries).await.unwrap();
-        let loaded = backend.load().await.unwrap();
-        assert_eq!(loaded.len(), 1);
-        assert!(loaded.contains_key("key1"));
-
-        // Test contains
-        assert!(backend.contains(&"key1".to_string()).await.unwrap());
-        assert!(!backend.contains(&"key2".to_string()).await.unwrap());
-
-        // Test remove
-        backend.remove(&"key1".to_string()).await.unwrap();
-        assert!(!backend.contains(&"key1".to_string()).await.unwrap());
-
-        // Test clear
-        backend.save(&entries).await.unwrap();
-        backend.clear().await.unwrap();
-        let loaded = backend.load().await.unwrap();
-        assert!(loaded.is_empty());
-    }
-
-    #[tokio::test]
     async fn test_memory_backend_clone() {
         let backend1: MemoryBackend<String, String> = MemoryBackend::new();
         let backend2 = backend1.clone();

--- a/tests/backend_operations.rs
+++ b/tests/backend_operations.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use threatflux_cache::backends::memory::MemoryBackend;
+use threatflux_cache::{CacheEntry, StorageBackend};
+
+#[cfg(feature = "filesystem-backend")]
+use tempfile::TempDir;
+#[cfg(feature = "filesystem-backend")]
+use threatflux_cache::backends::filesystem::FilesystemBackend;
+
+async fn run_basic_backend_tests<B>(backend: B)
+where
+    B: StorageBackend<Key = String, Value = String, Metadata = ()>,
+{
+    // Test empty state
+    let loaded = backend.load().await.unwrap();
+    assert!(loaded.is_empty());
+
+    // Test save and load
+    let mut entries = HashMap::new();
+    let entry = CacheEntry::new("key1".to_string(), "value1".to_string());
+    entries.insert("key1".to_string(), vec![entry]);
+
+    backend.save(&entries).await.unwrap();
+    let loaded = backend.load().await.unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert!(loaded.contains_key("key1"));
+
+    // Test contains
+    assert!(backend.contains(&"key1".to_string()).await.unwrap());
+    assert!(!backend.contains(&"key2".to_string()).await.unwrap());
+
+    // Test remove
+    backend.remove(&"key1".to_string()).await.unwrap();
+    assert!(!backend.contains(&"key1".to_string()).await.unwrap());
+
+    // Test clear
+    backend.save(&entries).await.unwrap();
+    backend.clear().await.unwrap();
+    let loaded = backend.load().await.unwrap();
+    assert!(loaded.is_empty());
+}
+
+#[tokio::test]
+async fn memory_backend_operations() {
+    let backend: MemoryBackend<String, String> = MemoryBackend::new();
+    run_basic_backend_tests(backend).await;
+}
+
+#[cfg(feature = "filesystem-backend")]
+#[tokio::test]
+async fn filesystem_backend_operations() {
+    let temp_dir = TempDir::new().unwrap();
+    let backend: FilesystemBackend<String, String> =
+        FilesystemBackend::new(temp_dir.path()).await.unwrap();
+    run_basic_backend_tests(backend).await;
+}


### PR DESCRIPTION
## Summary
- consolidate shared backend operation tests into a single integration test
- remove duplicated per-backend operation tests

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-features`
- `cargo test --all-features`
- `cargo doc --all-features --no-deps`
- `cargo audit`
- `cargo deny check` *(failed: failed to fetch advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68a5162da7b8832784c9c5da5de4a6f8