### PR TITLE
refactor: reduce complexity across modules

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -38,14 +38,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     cache.put("user:2".to_string(), user2.clone()).await?;
 
     // Retrieve a user
-    if let Some(user) = cache.get(&"user:1".to_string()).await? {
-        println!("Found user: {user:?}");
-    }
+    let user = cache
+        .get(&"user:1".to_string())
+        .await?
+        .expect("user not found");
+    println!("Found user: {user:?}");
 
     // Check if a key exists
-    if cache.contains(&"user:2".to_string()).await? {
-        println!("User 2 exists in cache");
-    }
+    assert!(cache.contains(&"user:2".to_string()).await?);
+    println!("User 2 exists in cache");
 
     // Get cache statistics
     let stats = cache.get_stats().await;
@@ -55,9 +56,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     );
 
     // Remove a user
-    if let Some(removed) = cache.remove(&"user:1".to_string()).await? {
-        println!("Removed user: {removed:?}");
-    }
+    let removed = cache
+        .remove(&"user:1".to_string())
+        .await?
+        .expect("user not found");
+    println!("Removed user: {removed:?}");
 
     // Clear the cache
     cache.clear().await?;

--- a/examples/simple_test.rs
+++ b/examples/simple_test.rs
@@ -35,44 +35,32 @@ async fn main() -> std::result::Result<(), Box<dyn Error>> {
 
     // Test basic operations
     println!("📝 Testing basic cache operations...");
+    let key = "test_key".to_string();
 
     // Put operation
-    cache.put("test_key".to_string(), test_data.clone()).await?;
+    cache.put(key.clone(), test_data.clone()).await?;
     println!("✅ Put operation successful");
 
     // Get operation
-    if let Some(retrieved) = cache.get(&"test_key".to_string()).await? {
-        assert_eq!(retrieved, test_data);
-        println!("✅ Get operation successful - data matches");
-    } else {
-        return Err("Failed to retrieve data from cache".into());
-    }
+    assert_eq!(cache.get(&key).await?, Some(test_data.clone()));
+    println!("✅ Get operation successful - data matches");
 
     // Contains operation
-    if cache.contains(&"test_key".to_string()).await? {
-        println!("✅ Contains operation successful");
-    } else {
-        return Err("Contains check failed".into());
-    }
+    assert!(cache.contains(&key).await?);
+    println!("✅ Contains operation successful");
 
     // Cache statistics
     let len = cache.len().await?;
     println!("📊 Cache has {len} entries");
 
     // Remove operation
-    if let Some(removed) = cache.remove(&"test_key".to_string()).await? {
-        assert_eq!(removed, test_data);
-        println!("✅ Remove operation successful");
-    } else {
-        return Err("Remove operation failed".into());
-    }
+    let removed = cache.remove(&key).await?.expect("Remove operation failed");
+    assert_eq!(removed, test_data);
+    println!("✅ Remove operation successful");
 
     // Verify empty after removal
-    if cache.is_empty().await? {
-        println!("✅ Cache is empty after removal");
-    } else {
-        return Err("Cache should be empty after removal".into());
-    }
+    assert!(cache.is_empty().await?);
+    println!("✅ Cache is empty after removal");
 
     // Clear operation
     cache.clear().await?;


### PR DESCRIPTION
## Summary
- simplify example `main` functions to lower cyclomatic complexity
- streamline filesystem backend save/load and tests
- condense search matching and TTL eviction logic

## Testing
- `cargo test`
- `cargo llvm-cov --summary-only` *(fails: command did not complete in time)*
- `make all` *(fails: cargo deny fetch error)*


------
https://chatgpt.com/codex/tasks/task_e_68a51bfa5f0483279d9c6f4ed28ce442