### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -263,7 +263,7 @@ jobs:
         EOF
 
     - name: Setup Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
       if: github.ref == 'refs/heads/main'
       with:
         enablement: true  # Enable Pages if not already enabled

--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -43,7 +43,7 @@ jobs:
           echo '<meta http-equiv="refresh" content="0; url=threatflux_cache/index.html">' > target/doc/index.html
           
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4.0.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -264,7 +264,7 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@cc18fa8621ebc2961c68a319279dcf9e91aa5791  # v3
       with:
         languages: rust
         queries: security-extended,security-and-quality
@@ -286,7 +286,7 @@ jobs:
       run: cargo build --all-features
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@cc18fa8621ebc2961c68a319279dcf9e91aa5791  # v3
       with:
         category: "/language:rust"
 


### PR DESCRIPTION
## Summary
- pin configure-pages to a specific commit
- pin CodeQL action to a specific commit

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a5e2f9c4c48327b600c0260f3c873d