### PR TITLE
refactor: reduce duplication

### DIFF
--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -3,29 +3,19 @@
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
-use std::hash::Hash;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::backends::{BackendKey, BackendMeta, BackendValue};
 use crate::{CacheEntry, EntryMetadata, Result, StorageBackend};
 
 /// In-memory storage backend
 #[allow(clippy::type_complexity)]
-pub struct MemoryBackend<K, V, M = ()>
-where
-    K: Hash + Eq + Clone + Send + Sync,
-    V: Clone + Send + Sync,
-    M: Clone + Send + Sync,
-{
+pub struct MemoryBackend<K: BackendKey, V: BackendValue, M: BackendMeta = ()> {
     data: Arc<RwLock<HashMap<K, Vec<CacheEntry<K, V, M>>>>>,
 }
 
-impl<K, V, M> MemoryBackend<K, V, M>
-where
-    K: Hash + Eq + Clone + Send + Sync,
-    V: Clone + Send + Sync,
-    M: Clone + Send + Sync,
-{
+impl<K: BackendKey, V: BackendValue, M: BackendMeta> MemoryBackend<K, V, M> {
     /// Create a new memory backend
     pub fn new() -> Self {
         Self {
@@ -34,23 +24,13 @@ where
     }
 }
 
-impl<K, V, M> Default for MemoryBackend<K, V, M>
-where
-    K: Hash + Eq + Clone + Send + Sync,
-    V: Clone + Send + Sync,
-    M: Clone + Send + Sync,
-{
+impl<K: BackendKey, V: BackendValue, M: BackendMeta> Default for MemoryBackend<K, V, M> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K, V, M> Clone for MemoryBackend<K, V, M>
-where
-    K: Hash + Eq + Clone + Send + Sync,
-    V: Clone + Send + Sync,
-    M: Clone + Send + Sync,
-{
+impl<K: BackendKey, V: BackendValue, M: BackendMeta> Clone for MemoryBackend<K, V, M> {
     fn clone(&self) -> Self {
         Self {
             data: Arc::clone(&self.data),
@@ -61,9 +41,9 @@ where
 #[async_trait]
 impl<K, V, M> StorageBackend for MemoryBackend<K, V, M>
 where
-    K: Serialize + DeserializeOwned + Hash + Eq + Clone + Send + Sync + 'static,
-    V: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-    M: Serialize + DeserializeOwned + Clone + Send + Sync + EntryMetadata,
+    K: BackendKey + Serialize + DeserializeOwned + 'static,
+    V: BackendValue + Serialize + DeserializeOwned + 'static,
+    M: BackendMeta + Serialize + DeserializeOwned + EntryMetadata,
 {
     type Key = K;
     type Value = V;

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,5 +1,19 @@
 //! Storage backend implementations
 
+use std::hash::Hash;
+
+/// Bounds required for backend keys
+pub trait BackendKey: Hash + Eq + Clone + Send + Sync {}
+impl<T> BackendKey for T where T: Hash + Eq + Clone + Send + Sync {}
+
+/// Bounds required for backend values
+pub trait BackendValue: Clone + Send + Sync {}
+impl<T> BackendValue for T where T: Clone + Send + Sync {}
+
+/// Bounds required for backend metadata
+pub trait BackendMeta: Clone + Send + Sync {}
+impl<T> BackendMeta for T where T: Clone + Send + Sync {}
+
 pub mod memory;
 
 #[cfg(feature = "filesystem-backend")]


### PR DESCRIPTION
## Summary
- centralize backend trait bounds to remove repeated generics
- streamline eviction strategies using reusable macro and shared test context
- add backend helper for filesystem tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo doc --no-deps`
- `cargo build`
- `cargo audit` *(fails: no such command)*
- `cargo deny check` *(fails: failed to fetch advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68a7886c58e08327be2a14888c7f3c20