### PR TITLE
refactor: reduce storage duplication

### DIFF
--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::backends::{BackendKey, BackendMeta, BackendValue};
+use crate::storage::EntryMap;
 use crate::{CacheEntry, EntryMetadata, Result, StorageBackend};
 
 /// In-memory storage backend
@@ -49,13 +50,13 @@ where
     type Value = V;
     type Metadata = M;
 
-    async fn save(&self, entries: &HashMap<K, Vec<CacheEntry<K, V, M>>>) -> Result<()> {
+    async fn save(&self, entries: &EntryMap<K, V, M>) -> Result<()> {
         let mut data = self.data.write().await;
         *data = entries.clone();
         Ok(())
     }
 
-    async fn load(&self) -> Result<HashMap<K, Vec<CacheEntry<K, V, M>>>> {
+    async fn load(&self) -> Result<EntryMap<K, V, M>> {
         let data = self.data.read().await;
         Ok(data.clone())
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -7,6 +7,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
 use std::hash::Hash;
 
+/// Convenience alias for the internal storage map
+pub type EntryMap<K, V, M> = HashMap<K, Vec<CacheEntry<K, V, M>>>;
+
 /// Trait for cache storage backends
 #[async_trait]
 pub trait StorageBackend: Send + Sync + 'static {
@@ -18,15 +21,10 @@ pub trait StorageBackend: Send + Sync + 'static {
     type Metadata: Serialize + DeserializeOwned + Clone + Send + Sync;
 
     /// Save entries to storage
-    async fn save(
-        &self,
-        entries: &HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>,
-    ) -> Result<()>;
+    async fn save(&self, entries: &EntryMap<Self::Key, Self::Value, Self::Metadata>) -> Result<()>;
 
     /// Load entries from storage
-    async fn load(
-        &self,
-    ) -> Result<HashMap<Self::Key, Vec<CacheEntry<Self::Key, Self::Value, Self::Metadata>>>>;
+    async fn load(&self) -> Result<EntryMap<Self::Key, Self::Value, Self::Metadata>>;
 
     /// Remove entries for a specific key
     async fn remove(&self, key: &Self::Key) -> Result<()>;


### PR DESCRIPTION
## Summary
- add reusable EntryMap alias and switch StorageBackend to it
- inline async cache trait implementation
- simplify memory and filesystem backend save/load signatures

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`
- `cargo deny check` *(failed: failed to fetch advisory database)*
- `npx -y jscpd --threshold 5 --format rust --reporters console src examples tests`
- `cargo build`
- `cargo doc --all-features --no-deps`
- `cargo build --examples --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68a90eefbc688327a4687587ffb3bd31