### PR TITLE
Refactor backend trait bounds to eliminate duplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ deny-docker: docker-build ## Run dependency validation in Docker
 
 codedup: ## Check for code duplication
 	@echo "$(CYAN)Checking code duplication...$(NC)"
-	@npx -y jscpd --threshold 5 --format rust --reporters console src examples tests 2>/dev/null || echo "$(YELLOW)Code duplication check requires npx$(NC)"
+	@npx -y jscpd --threshold 0.5 --format rust --reporters console src examples tests 2>/dev/null || echo "$(YELLOW)Code duplication check requires npx$(NC)"
 
 # =============================================================================
 # Testing Commands

--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -1,22 +1,31 @@
 //! In-memory storage backend
 
 use async_trait::async_trait;
-use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use crate::backends::{BackendKey, BackendMeta, BackendValue};
+use crate::backends::{StorageKey, StorageMeta, StorageValue};
 use crate::storage::EntryMap;
-use crate::{CacheEntry, EntryMetadata, Result, StorageBackend};
+use crate::{CacheEntry, Result, StorageBackend};
 
 /// In-memory storage backend
 #[allow(clippy::type_complexity)]
-pub struct MemoryBackend<K: BackendKey, V: BackendValue, M: BackendMeta = ()> {
+pub struct MemoryBackend<K, V, M = ()>
+where
+    K: StorageKey,
+    V: StorageValue,
+    M: StorageMeta,
+{
     data: Arc<RwLock<HashMap<K, Vec<CacheEntry<K, V, M>>>>>,
 }
 
-impl<K: BackendKey, V: BackendValue, M: BackendMeta> MemoryBackend<K, V, M> {
+impl<K, V, M> MemoryBackend<K, V, M>
+where
+    K: StorageKey,
+    V: StorageValue,
+    M: StorageMeta,
+{
     /// Create a new memory backend
     pub fn new() -> Self {
         Self {
@@ -25,13 +34,23 @@ impl<K: BackendKey, V: BackendValue, M: BackendMeta> MemoryBackend<K, V, M> {
     }
 }
 
-impl<K: BackendKey, V: BackendValue, M: BackendMeta> Default for MemoryBackend<K, V, M> {
+impl<K, V, M> Default for MemoryBackend<K, V, M>
+where
+    K: StorageKey,
+    V: StorageValue,
+    M: StorageMeta,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K: BackendKey, V: BackendValue, M: BackendMeta> Clone for MemoryBackend<K, V, M> {
+impl<K, V, M> Clone for MemoryBackend<K, V, M>
+where
+    K: StorageKey,
+    V: StorageValue,
+    M: StorageMeta,
+{
     fn clone(&self) -> Self {
         Self {
             data: Arc::clone(&self.data),
@@ -42,9 +61,9 @@ impl<K: BackendKey, V: BackendValue, M: BackendMeta> Clone for MemoryBackend<K, 
 #[async_trait]
 impl<K, V, M> StorageBackend for MemoryBackend<K, V, M>
 where
-    K: BackendKey + Serialize + DeserializeOwned + 'static,
-    V: BackendValue + Serialize + DeserializeOwned + 'static,
-    M: BackendMeta + Serialize + DeserializeOwned + EntryMetadata,
+    K: StorageKey,
+    V: StorageValue,
+    M: StorageMeta,
 {
     type Key = K;
     type Value = V;

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,5 +1,7 @@
 //! Storage backend implementations
 
+use crate::EntryMetadata;
+use serde::{de::DeserializeOwned, Serialize};
 use std::hash::Hash;
 
 /// Bounds required for backend keys
@@ -13,6 +15,18 @@ impl<T> BackendValue for T where T: Clone + Send + Sync {}
 /// Bounds required for backend metadata
 pub trait BackendMeta: Clone + Send + Sync {}
 impl<T> BackendMeta for T where T: Clone + Send + Sync {}
+
+/// Combined bounds for storage keys
+pub trait StorageKey: BackendKey + Serialize + DeserializeOwned + 'static {}
+impl<T> StorageKey for T where T: BackendKey + Serialize + DeserializeOwned + 'static {}
+
+/// Combined bounds for storage values
+pub trait StorageValue: BackendValue + Serialize + DeserializeOwned + 'static {}
+impl<T> StorageValue for T where T: BackendValue + Serialize + DeserializeOwned + 'static {}
+
+/// Combined bounds for storage metadata
+pub trait StorageMeta: BackendMeta + Serialize + DeserializeOwned + EntryMetadata {}
+impl<T> StorageMeta for T where T: BackendMeta + Serialize + DeserializeOwned + EntryMetadata {}
 
 pub mod memory;
 

--- a/tests/backend_operations.rs
+++ b/tests/backend_operations.rs
@@ -22,6 +22,9 @@ where
     entries.insert("key1".to_string(), vec![entry]);
 
     backend.save(&entries).await.unwrap();
+    let size = backend.size_bytes().await.unwrap();
+    assert!(size > 0);
+
     let loaded = backend.load().await.unwrap();
     assert_eq!(loaded.len(), 1);
     assert!(loaded.contains_key("key1"));
@@ -34,11 +37,14 @@ where
     backend.remove(&"key1".to_string()).await.unwrap();
     assert!(!backend.contains(&"key1".to_string()).await.unwrap());
 
-    // Test clear
+    // Test clear and compaction
     backend.save(&entries).await.unwrap();
+    backend.compact().await.unwrap();
     backend.clear().await.unwrap();
     let loaded = backend.load().await.unwrap();
     assert!(loaded.is_empty());
+    let size_after_clear = backend.size_bytes().await.unwrap();
+    assert!(size_after_clear <= size);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- consolidate common backend trait bounds into `StorageKey`, `StorageValue`, and `StorageMeta`
- refactor filesystem and memory backends to use shared bounds and reduce duplicate code
- strengthen duplicate code check and expand backend tests

## Testing
- `make fmt-check`
- `make lint`
- `make audit`
- `make deny` *(fails: failed to fetch advisory database)*
- `make codedup`
- `cargo test --quiet`
- `make msrv-check`
- `make feature-check` *(missing cargo-hack)*
- `make docs`
- `make build`
- `make examples`


------
https://chatgpt.com/codex/tasks/task_e_68a93fee5364832793098bac8751f2db