### PR TITLE
Complete Rust 1.95 migration and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,10 +178,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-    - name: Install Rust toolchain (1.81.0 - prometheus requirement)
-      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
-      with:
-        toolchain: 1.81.0
+      - name: Install Rust toolchain (1.95.0)
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+        with:
+        toolchain: 1.95.0
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-      - name: Install Rust toolchain (1.95.0)
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
-        with:
+    - name: Install Rust toolchain (1.95.0)
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
         toolchain: 1.95.0
 
     - name: Cache cargo

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -77,6 +79,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -302,6 +306,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -346,6 +352,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -395,6 +403,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4

--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -36,6 +36,8 @@ jobs:
         
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+        with:
+          toolchain: stable
         
       - name: Build Documentation
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
+        toolchain: stable
         components: rustfmt, clippy
 
     - name: Cache cargo
@@ -131,6 +132,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
+        toolchain: stable
         targets: ${{ matrix.target }}
 
     - name: Cache cargo
@@ -238,6 +240,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -81,6 +83,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
+        toolchain: stable
         components: clippy
 
     - name: Cache cargo
@@ -143,6 +146,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -271,6 +276,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Cache cargo
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -300,6 +307,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
+      with:
+        toolchain: stable
 
     - name: Check for unsafe code
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ anyhow = "1.0"
 
 [features]
 default = ["filesystem-backend", "json-serialization"]
-filesystem-backend = ["serde_json"]
+filesystem-backend = ["json-serialization"]
 json-serialization = ["serde_json"]
 bincode-serialization = ["bincode"]
 compression = ["flate2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 name = "threatflux-cache"
 version = "0.1.8"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.95.0"
 authors = ["ThreatFlux"]
 description = "A flexible async cache library for Rust with pluggable backends and serialization"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,10 @@ setup-dev: dev-setup ## (Deprecated) Use `make dev-setup` instead
 
 docker-build: ## Build Docker image for consistent environment
 	@echo "$(CYAN)Building Docker image...$(NC)"
-	@echo 'FROM rust:1.83-alpine\n\
-RUN apk add --no-cache pkgconfig musl-dev\n\
+	@echo 'FROM docker.io/threatflux/rust-cicd-template:base-rust-latest\n\
+RUN apt-get update && apt-get install -y pkg-config musl-dev build-essential curl git\n\
 RUN rustup component add rustfmt clippy\n\
-RUN cargo install cargo-audit cargo-deny cargo-llvm-cov cargo-hack\n\
+RUN cargo install cargo-chef cargo-audit cargo-deny cargo-llvm-cov cargo-hack\n\
 WORKDIR /workspace\n\
 ENV CARGO_TERM_COLOR=always\n\
 ENV RUST_BACKTRACE=1\n\
@@ -272,10 +272,10 @@ feature-check: ## Check all feature combinations with cargo-hack
 	@echo "$(CYAN)Checking feature combinations with cargo-hack...$(NC)"
 	@cargo hack check --feature-powerset --depth 2 --no-dev-deps 2>/dev/null || echo "$(YELLOW)Feature check requires cargo-hack (cargo install cargo-hack)$(NC)"
 
-msrv-check: ## Check Minimum Supported Rust Version (1.81.0)
-	@echo "$(CYAN)Checking MSRV (1.81.0)...$(NC)"
-	@rustup toolchain install 1.81.0 --profile minimal 2>/dev/null || true
-	@cargo +1.81.0 check --all-features && echo "$(GREEN)✅ MSRV check passed!$(NC)" || echo "$(RED)❌ MSRV check failed - code requires features from Rust > 1.81.0$(NC)"
+msrv-check: ## Check Minimum Supported Rust Version (1.95.0)
+	@echo "$(CYAN)Checking MSRV (1.95.0)...$(NC)"
+	@rustup toolchain install 1.95.0 --profile minimal 2>/dev/null || true
+	@cargo +1.95.0 check --all-features && echo "$(GREEN)✅ MSRV check passed!$(NC)" || echo "$(RED)❌ MSRV check failed - code requires features from Rust > 1.95.0$(NC)"
 
 # =============================================================================
 # Build Commands

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ docker-build: ## Build Docker image for consistent environment
 	@echo 'FROM rust:1.95-bookworm\n\
 RUN apt-get update && apt-get install -y pkg-config build-essential curl git\n\
 RUN rustup component add rustfmt clippy\n\
-RUN cargo install cargo-chef cargo-audit cargo-deny cargo-llvm-cov cargo-hack\n\
+RUN cargo install --locked cargo-chef cargo-audit cargo-deny cargo-llvm-cov cargo-hack\n\
 WORKDIR /workspace\n\
 ENV CARGO_TERM_COLOR=always\n\
 ENV RUST_BACKTRACE=1\n\
@@ -270,12 +270,14 @@ test-integration: ## Run integration tests
 
 feature-check: ## Check all feature combinations with cargo-hack
 	@echo "$(CYAN)Checking feature combinations with cargo-hack...$(NC)"
-	@cargo hack check --feature-powerset --depth 2 --no-dev-deps 2>/dev/null || echo "$(YELLOW)Feature check requires cargo-hack (cargo install cargo-hack)$(NC)"
+	@command -v cargo-hack >/dev/null 2>&1 || { echo "$(RED)Feature check requires cargo-hack (cargo install cargo-hack)$(NC)"; exit 1; }
+	@cargo hack check --feature-powerset --depth 2 --no-dev-deps
 
 msrv-check: ## Check Minimum Supported Rust Version (1.95.0)
 	@echo "$(CYAN)Checking MSRV (1.95.0)...$(NC)"
 	@rustup toolchain install 1.95.0 --profile minimal 2>/dev/null || true
-	@cargo +1.95.0 check --all-features && echo "$(GREEN)✅ MSRV check passed!$(NC)" || echo "$(RED)❌ MSRV check failed - code requires features from Rust > 1.95.0$(NC)"
+	@cargo +1.95.0 check --all-features
+	@echo "$(GREEN)✅ MSRV check passed!$(NC)"
 
 # =============================================================================
 # Build Commands

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ setup-dev: dev-setup ## (Deprecated) Use `make dev-setup` instead
 
 docker-build: ## Build Docker image for consistent environment
 	@echo "$(CYAN)Building Docker image...$(NC)"
-	@echo 'FROM docker.io/threatflux/rust-cicd-template:base-rust-latest\n\
-RUN apt-get update && apt-get install -y pkg-config musl-dev build-essential curl git\n\
+	@echo 'FROM rust:1.95-bookworm\n\
+RUN apt-get update && apt-get install -y pkg-config build-essential curl git\n\
 RUN rustup component add rustfmt clippy\n\
 RUN cargo install cargo-chef cargo-audit cargo-deny cargo-llvm-cov cargo-hack\n\
 WORKDIR /workspace\n\

--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,10 @@ setup-dev: dev-setup ## (Deprecated) Use `make dev-setup` instead
 
 docker-build: ## Build Docker image for consistent environment
 	@echo "$(CYAN)Building Docker image...$(NC)"
-	@echo 'FROM rust:1.95-bookworm\n\
+	@echo 'FROM rust:1.95.0-bookworm\n\
 RUN apt-get update && apt-get install -y pkg-config build-essential curl git\n\
 RUN rustup component add rustfmt clippy\n\
-RUN cargo install --locked cargo-chef cargo-audit cargo-deny cargo-llvm-cov cargo-hack\n\
+RUN cargo install --locked cargo-chef@0.1.77 cargo-audit@0.22.2 cargo-deny@0.20.2 cargo-llvm-cov@0.8.7 cargo-hack@0.6.45\n\
 WORKDIR /workspace\n\
 ENV CARGO_TERM_COLOR=always\n\
 ENV RUST_BACKTRACE=1\n\

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Crates.io](https://img.shields.io/crates/v/threatflux-cache.svg)](https://crates.io/crates/threatflux-cache)
 [![Documentation](https://docs.rs/threatflux-cache/badge.svg)](https://docs.rs/threatflux-cache)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.95.0%2B-orange.svg)](https://www.rust-lang.org)
 [![CI](https://github.com/ThreatFlux/threatflux-cache/actions/workflows/ci.yml/badge.svg)](https://github.com/ThreatFlux/threatflux-cache/actions/workflows/ci.yml)
 [![Release](https://github.com/ThreatFlux/threatflux-cache/actions/workflows/release.yml/badge.svg)](https://github.com/ThreatFlux/threatflux-cache/actions/workflows/release.yml)
 [![Security](https://github.com/ThreatFlux/threatflux-cache/actions/workflows/security.yml/badge.svg)](https://github.com/ThreatFlux/threatflux-cache/actions/workflows/security.yml)

--- a/src/backends/filesystem.rs
+++ b/src/backends/filesystem.rs
@@ -35,14 +35,19 @@ where
     V: StorageValue,
     M: StorageMeta,
 {
-    /// Create a new filesystem backend with the given base path
+    /// Create a new filesystem backend with the given base path.
+    ///
+    /// JSON is the default when both serialization features are enabled. Use
+    /// [`Self::with_format`] to select Bincode explicitly.
     pub async fn new<P: AsRef<Path>>(base_path: P) -> Result<Self> {
         let base_path = base_path.as_ref().to_path_buf();
         fs::create_dir_all(&base_path).await?;
 
         Ok(Self {
             base_path,
-            #[cfg(feature = "json-serialization")]
+            #[cfg(all(feature = "json-serialization", feature = "bincode-serialization"))]
+            format: SerializationFormat::Json,
+            #[cfg(all(feature = "json-serialization", not(feature = "bincode-serialization")))]
             format: SerializationFormat::Json,
             #[cfg(all(not(feature = "json-serialization"), feature = "bincode-serialization"))]
             format: SerializationFormat::Bincode,
@@ -278,6 +283,13 @@ mod tests {
             let entries = &loaded["persistent_key"];
             assert_eq!(entries[0].value, "persistent_value");
         }
+    }
+
+    #[cfg(all(feature = "json-serialization", feature = "bincode-serialization"))]
+    #[tokio::test]
+    async fn test_mixed_serialization_features_default_to_json() {
+        let (_temp_dir, backend) = new_backend().await;
+        assert_eq!(backend.format, SerializationFormat::Json);
     }
 
     #[tokio::test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,8 +75,8 @@ mod tests {
 
     #[test]
     fn test_cache_error_variants() {
-        let io_err: CacheError = io::Error::new(io::ErrorKind::Other, "oops").into();
-        matches!(io_err, CacheError::Io(_));
+        let io_err: CacheError = io::Error::other("oops").into();
+        assert!(matches!(io_err, CacheError::Io(_)));
 
         let ser_err = CacheError::Serialization("ser".into());
         assert_eq!(format!("{ser_err}"), "Serialization error: ser");

--- a/src/search.rs
+++ b/src/search.rs
@@ -143,22 +143,19 @@ where
     fn matches(&self, query: &Self::Query) -> bool {
         let key_str = self.key.to_string();
         (query.include_expired || !self.is_expired())
-            && query.pattern.as_ref().map_or(true, |p| key_str.contains(p))
-            && query
-                .min_timestamp
-                .map_or(true, |min| self.timestamp >= min)
-            && query
-                .max_timestamp
-                .map_or(true, |max| self.timestamp <= max)
+            && query.pattern.as_ref().is_none_or(|p| key_str.contains(p))
+            && query.min_timestamp.is_none_or(|min| self.timestamp >= min)
+            && query.max_timestamp.is_none_or(|max| self.timestamp <= max)
             && query
                 .min_access_count
-                .map_or(true, |min| self.access_count >= min)
+                .is_none_or(|min| self.access_count >= min)
             && query
                 .max_access_count
-                .map_or(true, |max| self.access_count <= max)
-            && query.category.as_ref().map_or(true, |category| {
-                self.metadata.category().is_some_and(|c| c == category)
-            })
+                .is_none_or(|max| self.access_count <= max)
+            && query
+                .category
+                .as_ref()
+                .is_none_or(|category| self.metadata.category().is_some_and(|c| c == category))
     }
 }
 


### PR DESCRIPTION
## Summary
- Raise the declared MSRV, documented baseline, and dedicated MSRV job to Rust 1.95.0.
- Pin the Docker validation environment to Rust 1.95.0 and known-compatible Cargo tool versions.
- Make the JSON default explicit and tested when both filesystem serializers are enabled, while preserving explicit Bincode selection.
- Apply the Rust 1.95 Clippy migrations in search predicates and restore the missing assertion in the error conversion test.
- Make MSRV and feature-power-set Makefile gates fail on real errors instead of reporting false success.
- Repair pinned Rust setup steps across CI/CD workflows by declaring their intended toolchain.

## Validation
- `RUSTUP_TOOLCHAIN=1.95.0 make all`
- `cargo +1.95.0 hack check --feature-powerset --depth 2 --no-dev-deps` (37 combinations)
- all/default/no-default test and Clippy suites, including integration tests and doctests
- `cargo audit` (no vulnerabilities; optional Bincode 1.x is warning-only/unmaintained)
- `cargo deny check`, documentation, examples, and workflow YAML parsing
- exact Rust 1.95.0 Docker build and container smoke checks for all five pinned Cargo tools
- hosted current-head result: 31 passed and 6 conditionally skipped, with no failures or pending checks
- both actionable review threads addressed, confirmed, and resolved

Ready on signed head `dc862e6f0ed29699a4e1b348e131e61883ecc4ca`.
