### PR TITLE
ci: adopt ThreatFlux auto-release action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,114 @@
+name: Auto Release
+
+concurrency:
+  group: auto-release-${{ github.event.workflow_run.head_branch || github.ref_name || 'main' }}
+  cancel-in-progress: true
+
+on:
+  workflow_run:
+    workflows: ["CI", "Security"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: Version bump type
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check for Release
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      should_release: ${{ steps.decide.outputs.should_release }}
+      target_sha: ${{ steps.target.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref_name }}
+
+      - name: Determine target SHA
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if [[ ! "${WORKFLOW_RUN_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid workflow-run head SHA" >&2
+              exit 1
+            fi
+            echo "sha=${WORKFLOW_RUN_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check CI status
+        id: ci_status
+        run: |
+          TARGET_SHA="${{ steps.target.outputs.sha }}"
+          CI_STATUS=$(gh run list --workflow=ci.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          SECURITY_STATUS=$(gh run list --workflow=security.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          if [[ "$CI_STATUS" == "success" ]] && [[ "$SECURITY_STATUS" == "success" ]]; then
+            echo "all_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "all_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to attempt a release
+        id: decide
+        env:
+          ALL_PASSED: ${{ steps.ci_status.outputs.all_passed }}
+        run: |
+          # The release action itself no-ops when no conventional commit
+          # warrants a release, so this gate only enforces green required runs.
+          if [[ "${ALL_PASSED}" == "true" ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Create Release
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ needs.check.outputs.target_sha }}
+
+      - name: Release
+        id: release
+        uses: ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234 # v0.4.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bump: ${{ github.event.inputs.version_bump || 'auto' }}


### PR DESCRIPTION
Adopts the ThreatFlux auto-release action via a new `.github/workflows/auto-release.yml`.

## What it does

- On every successful **CI** and **Security** `workflow_run` for a push to `main` (or a manual `workflow_dispatch` with a bump-type input), a gate job verifies that *both* the CI and Security push runs for the target commit concluded `success`, then a release job runs `ThreatFlux/github_actions/release`.
- The action inspects conventional commits since the last tag, decides the semver bump (`auto`, or forced via the dispatch input), rewrites `Cargo.toml` / `Cargo.lock` version fields, creates the tag, and publishes the GitHub Release — all through the GitHub API. It runs no `git` or `cargo` commands at runtime.
- Merges containing only `chore:`/`docs:`/`ci:` style commits produce **no** release: the action no-ops when no conventional commit warrants a bump. (This PR itself uses a `ci:` prefix for exactly that reason.)

## Tag-trigger limitation — no dispatch chaining possible here

Tags created with `GITHUB_TOKEN` do not trigger tag-push workflows, so the existing `release.yml` (crates.io publish + GitHub release assets) will **not** fire automatically when auto-release creates a `v*.*.*` tag.

Normally we chain the tag pipelines with `gh workflow run`, but that step is **omitted** in this repo because `release.yml` has no `workflow_dispatch` trigger (and there is no `docker.yml`). Until `release.yml` gains a `workflow_dispatch` trigger, the crates.io publish pipeline must be started by other means (e.g. re-creating the tag with a PAT/manual push). Note also that `release.yml`'s provenance job requires an **annotated** tag reachable from `origin/main`, which any manual re-tagging must respect.

## release.yml / docker.yml bug fixes

None applied — the suspected template bugs are not present in this repo:

- "Build (native)" bash-without-`shell:` step: no such step exists; every multi-line bash step in `release.yml` already declares `shell: bash`, and the only matrix step without one (`cargo test --release --all-features --locked`) is shell-agnostic.
- Indented heredoc terminator in the crates.io visibility check: not present; the workflow uses a plain `curl | jq` pipeline.
- Windows packaging step missing a `.sha256` file: not present; there is no Windows packaging step (this workflow ships the `.crate` package only).
- `docker.yml` cosign gate: no `docker.yml` in this repo.

## Pinning

The release action ref is SHA-pinned (`16d779cd569c34743eb6683ca4c0ce105e9ad234`) corresponding to `v0.4.2`, matching the repo's existing pin-by-SHA convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
